### PR TITLE
Expand raw body on json_decode error

### DIFF
--- a/src/Http/Curl.php
+++ b/src/Http/Curl.php
@@ -70,6 +70,7 @@ class Curl
             $err = [
                 'msg' => 'Failed to parse server response. Err: '.json_last_error_msg(),
                 'code' => json_last_error(),
+                'body' => $body,
             ];
             $response = [
                 'error' => $err,


### PR DESCRIPTION
To make debugging and contacting support easier, we need to know the raw response that this lib couldn't parse.