### PR TITLE
Update firebase/php-jwt dependency to version 7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     ],
     "require": {
         "php": ">= 7.0",
-        "firebase/php-jwt": "^6.0",
+        "firebase/php-jwt": "^7.0",
         "myclabs/php-enum": "^1.7"
     },
     "autoload": {


### PR DESCRIPTION
"firebase/php-jwt": "^6.0" is deprecated